### PR TITLE
Add discardable results to constraint extension

### DIFF
--- a/Source/Shared/Extensions/NSLayoutConstraint+Extensions.swift
+++ b/Source/Shared/Extensions/NSLayoutConstraint+Extensions.swift
@@ -31,7 +31,7 @@ public extension NSLayoutConstraint {
   ///   - activate: Indicates if the constraints should be activated or not.
   ///   - insets: Insets that are applied as constants for the constraints.
   /// - Returns: A collection of layout constraints.
-  public static func pin(_ view: View,
+  @discardableResult public static func pin(_ view: View,
                   toView: View,
                   activate: Bool = true,
                   insets: EdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 0)) -> [NSLayoutConstraint?] {

--- a/UserInterface.podspec
+++ b/UserInterface.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "UserInterface"
   s.summary          = "A collection of convenience extensions specifically tailored to building user interfaces in Swift."
-  s.version          = "0.1.1"
+  s.version          = "0.1.2"
   s.homepage         = "https://github.com/zenangst/UserInterface"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
Reduces the number of warnings that can occur if the pin result is ignored.
The result of this extension method is now annotated with @discardableResult