### PR TITLE
Return [NSLayoutConstraint] instead of [NSLayoutConstraint?]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode9.3beta
+osx_image: xcode9.3
 language: objective-c
 
 script:

--- a/Source/Shared/Extensions/NSLayoutConstraint+Extensions.swift
+++ b/Source/Shared/Extensions/NSLayoutConstraint+Extensions.swift
@@ -34,7 +34,7 @@ public extension NSLayoutConstraint {
   @discardableResult public static func addAndPin(_ view: View,
                                                   toView: View,
                                                   activate: Bool = true,
-                                                  insets: EdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 0))  -> [NSLayoutConstraint?] {
+                                                  insets: EdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 0))  -> [NSLayoutConstraint] {
     toView.addSubview(view)
     return pin(view, toView: toView, activate: activate, insets: insets)
   }

--- a/Source/Shared/Extensions/NSLayoutConstraint+Extensions.swift
+++ b/Source/Shared/Extensions/NSLayoutConstraint+Extensions.swift
@@ -50,7 +50,7 @@ public extension NSLayoutConstraint {
   @discardableResult public static func pin(_ view: View,
                   toView: View,
                   activate: Bool = true,
-                  insets: EdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 0)) -> [NSLayoutConstraint?] {
+                  insets: EdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 0)) -> [NSLayoutConstraint] {
     let constraints = NSLayoutConstraint.constrain(activate: activate,
       view.leadingAnchor.constraint(equalTo: toView.leadingAnchor, constant: insets.left),
       view.trailingAnchor.constraint(equalTo: toView.trailingAnchor, constant: -insets.right),
@@ -58,6 +58,6 @@ public extension NSLayoutConstraint {
       view.bottomAnchor.constraint(equalTo: toView.bottomAnchor, constant: -insets.bottom)
     )
 
-    return constraints
+    return constraints.compactMap { $0 }
   }
 }

--- a/Source/Shared/Extensions/NSLayoutConstraint+Extensions.swift
+++ b/Source/Shared/Extensions/NSLayoutConstraint+Extensions.swift
@@ -11,7 +11,7 @@ public extension NSLayoutConstraint {
   ///   - activate: Indicates if the constraints should be activated or not.
   ///   - constraints: The constraints that should be applied.
   /// - Returns: The constraints that was applied to the view.
-  @discardableResult public static func constrain(activate: Bool = true, _ constraints: NSLayoutConstraint?...) -> [NSLayoutConstraint?] {
+  @discardableResult public static func constrain(activate: Bool = true, _ constraints: NSLayoutConstraint?...) -> [NSLayoutConstraint] {
     for constraint in constraints {
       (constraint?.firstItem as? View)?.translatesAutoresizingMaskIntoConstraints = false
     }
@@ -20,7 +20,7 @@ public extension NSLayoutConstraint {
       NSLayoutConstraint.activate(constraints.compactMap { $0 })
     }
 
-    return constraints
+    return constraints.compactMap { $0 }
   }
 
   /// Add view as a sub view an pin constraints to parent view.

--- a/Source/iOS+tvOS/Extensions/NSLayoutConstraints+iOS.swift
+++ b/Source/iOS+tvOS/Extensions/NSLayoutConstraints+iOS.swift
@@ -12,7 +12,7 @@ public extension NSLayoutConstraint {
   @discardableResult public static func addAndPin(_ layoutGuide: UILayoutGuide,
                                                   toView: View,
                                                   activate: Bool = true,
-                                                  insets: EdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 0))  -> [NSLayoutConstraint?] {
+                                                  insets: EdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 0))  -> [NSLayoutConstraint] {
     toView.addLayoutGuide(layoutGuide)
     return pin(layoutGuide, toView: toView, activate: activate, insets: insets)
   }

--- a/Source/iOS+tvOS/Extensions/NSLayoutConstraints+iOS.swift
+++ b/Source/iOS+tvOS/Extensions/NSLayoutConstraints+iOS.swift
@@ -28,7 +28,7 @@ public extension NSLayoutConstraint {
   @discardableResult public static func pin(_ layoutGuide: UILayoutGuide,
                          toView: View,
                          activate: Bool = true,
-                         insets: EdgeInsets = .zero) -> [NSLayoutConstraint?] {
+                         insets: EdgeInsets = .zero) -> [NSLayoutConstraint] {
     let constraints = NSLayoutConstraint.constrain(activate: activate,
       layoutGuide.leadingAnchor.constraint(equalTo: toView.leadingAnchor, constant: insets.left),
       layoutGuide.trailingAnchor.constraint(equalTo: toView.trailingAnchor, constant: -insets.right),
@@ -36,6 +36,6 @@ public extension NSLayoutConstraint {
       layoutGuide.bottomAnchor.constraint(equalTo: toView.bottomAnchor, constant: -insets.bottom)
     )
 
-    return constraints
+    return constraints.compactMap { $0 }
   }
 }

--- a/Tests/iOS+tvOS/NSLayoutConstraintsTests.swift
+++ b/Tests/iOS+tvOS/NSLayoutConstraintsTests.swift
@@ -8,10 +8,10 @@ class NSLayoutConstraintsTests: XCTestCase {
     viewB.addSubview(viewA)
     let constraints = NSLayoutConstraint.pin(viewA, toView: viewB, insets: .init(top: 10, left: 10, bottom: 10, right: 10))
 
-    XCTAssertEqual(constraints[0]?.constant, 10)
-    XCTAssertEqual(constraints[1]?.constant, -10)
-    XCTAssertEqual(constraints[2]?.constant, 10)
-    XCTAssertEqual(constraints[3]?.constant, -10)
+    XCTAssertEqual(constraints[0].constant, 10)
+    XCTAssertEqual(constraints[1].constant, -10)
+    XCTAssertEqual(constraints[2].constant, 10)
+    XCTAssertEqual(constraints[3].constant, -10)
   }
 
   func testConstraints() {
@@ -26,13 +26,13 @@ class NSLayoutConstraintsTests: XCTestCase {
 
     XCTAssertEqual(constraints.count, 2)
 
-    XCTAssertEqual(constraints[0]?.isActive, false)
-    XCTAssertEqual(constraints[0]?.firstAnchor, viewA.centerXAnchor)
-    XCTAssertEqual(constraints[0]?.secondAnchor, viewB.centerXAnchor)
+    XCTAssertEqual(constraints[0].isActive, false)
+    XCTAssertEqual(constraints[0].firstAnchor, viewA.centerXAnchor)
+    XCTAssertEqual(constraints[0].secondAnchor, viewB.centerXAnchor)
 
-    XCTAssertEqual(constraints[1]?.isActive, false)
-    XCTAssertEqual(constraints[1]?.firstAnchor, viewA.centerYAnchor)
-    XCTAssertEqual(constraints[1]?.secondAnchor, viewB.centerYAnchor)
+    XCTAssertEqual(constraints[1].isActive, false)
+    XCTAssertEqual(constraints[1].firstAnchor, viewA.centerYAnchor)
+    XCTAssertEqual(constraints[1].secondAnchor, viewB.centerYAnchor)
   }
 
   func testAddAndPinView() {

--- a/Tests/macOS/NSLayoutConstraintsTests.swift
+++ b/Tests/macOS/NSLayoutConstraintsTests.swift
@@ -8,10 +8,10 @@ class NSLayoutConstraintsTests: XCTestCase {
     viewB.addSubview(viewA)
     let constraints = NSLayoutConstraint.pin(viewA, toView: viewB, insets: .init(top: 10, left: 10, bottom: 10, right: 10))
 
-    XCTAssertEqual(constraints[0]?.constant, 10)
-    XCTAssertEqual(constraints[1]?.constant, -10)
-    XCTAssertEqual(constraints[2]?.constant, 10)
-    XCTAssertEqual(constraints[3]?.constant, -10)
+    XCTAssertEqual(constraints[0].constant, 10)
+    XCTAssertEqual(constraints[1].constant, -10)
+    XCTAssertEqual(constraints[2].constant, 10)
+    XCTAssertEqual(constraints[3].constant, -10)
   }
 
   func testConstraints() {
@@ -25,7 +25,7 @@ class NSLayoutConstraintsTests: XCTestCase {
     )
 
     XCTAssertEqual(constraints.count, 2)
-    XCTAssertEqual(constraints[0]?.isActive, false)
-    XCTAssertEqual(constraints[1]?.isActive, false)
+    XCTAssertEqual(constraints[0].isActive, false)
+    XCTAssertEqual(constraints[1].isActive, false)
   }
 }

--- a/UserInterface.podspec
+++ b/UserInterface.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "UserInterface"
   s.summary          = "A collection of convenience extensions specifically tailored to building user interfaces in Swift."
-  s.version          = "0.1.3"
+  s.version          = "0.1.4"
   s.homepage         = "https://github.com/zenangst/UserInterface"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
This PR improves the return values of the constraint methods. Instead of returning optional values it will compact map the values before returning.