### PR TITLE
Improves registering cells on table and collection views

### DIFF
--- a/Source/iOS+tvOS/Extensions/UICollectionView+Extensions.swift
+++ b/Source/iOS+tvOS/Extensions/UICollectionView+Extensions.swift
@@ -18,11 +18,29 @@ public extension UICollectionView {
     self.delegate = delegate
   }
 
-  /// Register a cell using the cells computed `.reuseIdentifier`.
+  /// Register a cell(s) using the cells computed `.reuseIdentifier`.
   ///
-  /// - Parameter type: The type of cell that should be registred.
-  public func register(_ type: UICollectionViewCell.Type) {
-    register(type, forCellWithReuseIdentifier: type.reuseIdentifier)
+  /// - Parameter types: The type(s) of cell that should be registred.
+  public func register(_ types: UICollectionViewCell.Type ...) {
+    register(types)
+  }
+
+  /// Register a cells using the cells computed `.reuseIdentifier`.
+  ///
+  /// - Parameter types: The type of cell that should be registred.
+  public func register(_ types: [UICollectionViewCell.Type]) {
+    types.forEach { type in register(type, forCellWithReuseIdentifier: type.reuseIdentifier) }
+  }
+
+  public func dequeue<T: UICollectionViewCell>(_ type: T.Type,
+                                               for indexPath: IndexPath,
+                                               closure: ((T) -> Void)? = nil) -> T {
+    if let cell = dequeueReusableCell(withReuseIdentifier: type.reuseIdentifier, for: indexPath) as? T {
+      closure?(cell)
+      return cell
+    }
+    assertionFailure("Failed to dequeue \(type)")
+    return type.init()
   }
 
   /// Dequeue and configure a cell at a specific index path.
@@ -38,11 +56,11 @@ public extension UICollectionView {
                                            with model: M,
                                            for indexPath: IndexPath,
                                            closure: ((T, M) -> Void)? = nil) -> T {
-    if let cell = dequeueReusableCell(withReuseIdentifier: type.reuseIdentifier, for: indexPath) as? T {
+    if let cell = dequeue(type, for: indexPath, closure: { (cell) in
       closure?(cell, model)
+    }) as? T {
       return cell
     }
-    assertionFailure("Failed to dequeue \(type)")
     return type.init()
   }
 }

--- a/Source/iOS+tvOS/Extensions/UITableView+Extensions.swift
+++ b/Source/iOS+tvOS/Extensions/UITableView+Extensions.swift
@@ -16,11 +16,18 @@ public extension UITableView {
     self.delegate = delegate
   }
 
-  /// Register a cell using the cells computed `.reuseIdentifier`.
+  /// Register a cell(s) using the cells computed `.reuseIdentifier`.
   ///
-  /// - Parameter type: The type of cell that should be registred.
-  public func register(_ type: UITableViewCell.Type) {
-    register(type, forCellReuseIdentifier: type.reuseIdentifier)
+  /// - Parameter types: The type(s) of cell that should be registred.
+  public func register(_ types: UITableViewCell.Type ...) {
+    register(types)
+  }
+
+  /// Register a cell(s) using the cells computed `.reuseIdentifier`.
+  ///
+  /// - Parameter types: The types of cell that should be registred.
+  public func register(_ types: [UITableViewCell.Type]) {
+    types.forEach { type in register(type, forCellReuseIdentifier: type.reuseIdentifier) }
   }
 
   /// Dequeue and configure a cell at a specific index path.

--- a/Source/macOS/Extensions/NSCollectionView+Extensions.swift
+++ b/Source/macOS/Extensions/NSCollectionView+Extensions.swift
@@ -17,11 +17,19 @@ public extension NSCollectionView {
     self.dataSource = dataSource
   }
 
-  /// Register a cell using the cells computed `.reuseIdentifier`.
+  /// Register a cell(s) using the cells computed `.reuseIdentifier`.
   ///
   /// - Parameter type: The type of cell that should be registred.
-  public func register(_ type: NSCollectionViewItem.Type) {
-    register(type, forItemWithIdentifier: NSUserInterfaceItemIdentifier(rawValue: type.reuseIdentifier))
+  public func register(_ types: NSCollectionViewItem.Type ...) {
+    register(types)
+  }
+
+  /// Register a cells using the cells computed `.reuseIdentifier`.
+  ///
+  /// - Parameter types: The types of cell that should be registred.
+  public func register(_ types: [NSCollectionViewItem.Type]) {
+    types.forEach { type in register(type,
+                                     forItemWithIdentifier: NSUserInterfaceItemIdentifier(rawValue: type.reuseIdentifier)) }
   }
 
   /// Dequeue and configure a cell at a specific index path.


### PR DESCRIPTION
The `UITableView` and `UICollectionView` registration methods can now take an array of types to register.