### PR TITLE
Add Shadow struct for settings shadows to views

### DIFF
--- a/Source/Shared/Structs/Shadow.swift
+++ b/Source/Shared/Structs/Shadow.swift
@@ -1,0 +1,22 @@
+#if os(macOS)
+import Cocoa
+public typealias ShadowColor = NSColor
+#else
+import UIKit
+public typealias ShadowColor = UIColor
+#endif
+
+public struct Shadow {
+  let color: ShadowColor
+  let offset: CGSize
+  let opacity: Float
+  let radius: CGFloat
+
+  public init(color: ShadowColor, offset: CGSize = .zero,
+              opacity: Float = 1.0, radius: CGFloat = 0.0) {
+    self.color = color
+    self.offset = offset
+    self.opacity = opacity
+    self.radius = radius
+  }
+}

--- a/Source/iOS+tvOS/Extensions/UIView+Extensions.swift
+++ b/Source/iOS+tvOS/Extensions/UIView+Extensions.swift
@@ -10,4 +10,11 @@ public extension UIView {
   public func addSubview(_ view: UIView, pin: Bool = false, insets: UIEdgeInsets = .zero) -> [NSLayoutConstraint] {
     return NSLayoutConstraint.addAndPin(view, toView: self, insets: insets)
   }
+
+  public func add(_ shadow: Shadow) {
+    layer.shadowColor = shadow.color.cgColor
+    layer.shadowRadius = shadow.radius
+    layer.shadowOffset = shadow.offset
+    layer.shadowOpacity = shadow.opacity
+  }
 }

--- a/Tests/iOS+tvOS/UIViewTests.swift
+++ b/Tests/iOS+tvOS/UIViewTests.swift
@@ -12,4 +12,41 @@ class UIViewTests: XCTestCase {
 
     XCTAssertEqual(superview.subviews, [viewA, viewB, viewC])
   }
+
+  func testPinView() {
+    let viewA = UIView()
+    let viewB = UIView()
+    let constraints = viewA.addSubview(viewB, pin: true,
+                     insets: .init(top: 10, left: 10, bottom: 10, right: 10))
+
+    guard constraints.count == 4 else {
+      XCTFail("Wrong number of constraints")
+      return
+    }
+
+    XCTAssertEqual(viewB.superview, viewA)
+
+    do {
+      let constraint = constraints[0]
+      XCTAssertTrue(constraint.isActive)
+      XCTAssertTrue((constraint.firstItem as? UIView) == viewB)
+      XCTAssertTrue((constraint.secondItem as? UIView) == viewA)
+    }
+  }
+
+  func testAddShadow() {
+    let view = UIView()
+    let color = UIColor.red
+    let offset = CGSize.init(width: 0, height: 2)
+    let opacity: Float = 0.75
+    let radius: CGFloat = 8
+    let shadow = Shadow(color: color, offset: offset, opacity: opacity, radius: radius)
+
+    view.add(shadow)
+
+    XCTAssertEqual(view.layer.shadowColor, color.cgColor)
+    XCTAssertEqual(view.layer.shadowOffset, offset)
+    XCTAssertEqual(view.layer.shadowOpacity, opacity)
+    XCTAssertEqual(view.layer.shadowRadius, radius)
+  }
 }

--- a/UserInterface.podspec
+++ b/UserInterface.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "UserInterface"
   s.summary          = "A collection of convenience extensions specifically tailored to building user interfaces in Swift."
-  s.version          = "0.2.0"
+  s.version          = "0.3.0"
   s.homepage         = "https://github.com/zenangst/UserInterface"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/UserInterface.xcodeproj/project.pbxproj
+++ b/UserInterface.xcodeproj/project.pbxproj
@@ -66,6 +66,9 @@
 		BDF8BCFE214D8A6D00D1C5E1 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8BCFC214D8A6D00D1C5E1 /* UIView+Extensions.swift */; };
 		BDF8BD00214D8D5700D1C5E1 /* UITextField+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8BCFF214D8D5700D1C5E1 /* UITextField+Extensions.swift */; };
 		BDF8BD01214D8D5700D1C5E1 /* UITextField+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8BCFF214D8D5700D1C5E1 /* UITextField+Extensions.swift */; };
+		BDF8BD04214D8F0D00D1C5E1 /* Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8BD03214D8F0D00D1C5E1 /* Shadow.swift */; };
+		BDF8BD05214D8F0D00D1C5E1 /* Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8BD03214D8F0D00D1C5E1 /* Shadow.swift */; };
+		BDF8BD06214D8F0D00D1C5E1 /* Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8BD03214D8F0D00D1C5E1 /* Shadow.swift */; };
 		D284B1051F79038B00D94AF3 /* UserInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D284B0FC1F79038B00D94AF3 /* UserInterface.framework */; };
 		D284B1381F7906DB00D94AF3 /* Info-iOS-Tests.plist in Resources */ = {isa = PBXBuildFile; fileRef = D284B12F1F7906DA00D94AF3 /* Info-iOS-Tests.plist */; };
 		D284B1391F7906DB00D94AF3 /* Info-tvOS-Tests.plist in Resources */ = {isa = PBXBuildFile; fileRef = D284B1301F7906DA00D94AF3 /* Info-tvOS-Tests.plist */; };
@@ -140,6 +143,7 @@
 		BDD89C63209711220041C951 /* UIStackView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extensions.swift"; sourceTree = "<group>"; };
 		BDF8BCFC214D8A6D00D1C5E1 /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		BDF8BCFF214D8D5700D1C5E1 /* UITextField+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extensions.swift"; sourceTree = "<group>"; };
+		BDF8BD03214D8F0D00D1C5E1 /* Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shadow.swift; sourceTree = "<group>"; };
 		D284B0FC1F79038B00D94AF3 /* UserInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UserInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D284B1041F79038B00D94AF3 /* UserInterface-tvOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UserInterface-tvOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D284B1181F79039F00D94AF3 /* UserInterface.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UserInterface.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -247,14 +251,14 @@
 			isa = PBXGroup;
 			children = (
 				BD7222002094F4D500D28B9C /* NSLayoutConstraints+iOS.swift */,
+				BD2CF3F220AB0BDC00888874 /* UIButton+Extensions.swift */,
 				BD7221E72094F3AB00D28B9C /* UICollectionView+Extensions.swift */,
 				BD7221E62094F3AB00D28B9C /* UICollectionViewCell+Extensions.swift */,
+				BD2CF3EF20AB07C500888874 /* UIImageView+Extensions.swift */,
+				BD2CF3EC20AB06C700888874 /* UILabel+Extensions.swift */,
 				BDD89C63209711220041C951 /* UIStackView+Extensions.swift */,
 				BD7221F02094F3E000D28B9C /* UITableView+Extensions.swift */,
 				BD7221EF2094F3E000D28B9C /* UITableViewCell+Extensions.swift */,
-				BD2CF3EC20AB06C700888874 /* UILabel+Extensions.swift */,
-				BD2CF3EF20AB07C500888874 /* UIImageView+Extensions.swift */,
-				BD2CF3F220AB0BDC00888874 /* UIButton+Extensions.swift */,
 				BDF8BCFC214D8A6D00D1C5E1 /* UIView+Extensions.swift */,
 				BDF8BCFF214D8D5700D1C5E1 /* UITextField+Extensions.swift */,
 			);
@@ -271,6 +275,14 @@
 				BD72220A20963FFB00D28B9C /* NSTableView+Extensions.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		BDF8BD02214D8EFD00D1C5E1 /* Structs */ = {
+			isa = PBXGroup;
+			children = (
+				BDF8BD03214D8F0D00D1C5E1 /* Shadow.swift */,
+			);
+			path = Structs;
 			sourceTree = "<group>";
 		};
 		D284B0F41F79024300D94AF3 /* macOS */ = {
@@ -386,6 +398,7 @@
 		D5C6296E1C3A809D007F7B7C /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				BDF8BD02214D8EFD00D1C5E1 /* Structs */,
 				BD7221E32094F38A00D28B9C /* Extensions */,
 				BD7221E12094F36F00D28B9C /* TypeAlias */,
 			);
@@ -701,6 +714,7 @@
 				BD2CF3F120AB07C500888874 /* UIImageView+Extensions.swift in Sources */,
 				BD2CF3EE20AB06C700888874 /* UILabel+Extensions.swift in Sources */,
 				BD7221F72094F41100D28B9C /* View+Extensions.swift in Sources */,
+				BDF8BD06214D8F0D00D1C5E1 /* Shadow.swift in Sources */,
 				BDD89C65209711220041C951 /* UIStackView+Extensions.swift in Sources */,
 				BD7222022094F4D500D28B9C /* NSLayoutConstraints+iOS.swift in Sources */,
 			);
@@ -745,6 +759,7 @@
 				BD2CF3F020AB07C500888874 /* UIImageView+Extensions.swift in Sources */,
 				BD2CF3ED20AB06C700888874 /* UILabel+Extensions.swift in Sources */,
 				BD7221F82094F41200D28B9C /* View+Extensions.swift in Sources */,
+				BDF8BD04214D8F0D00D1C5E1 /* Shadow.swift in Sources */,
 				BDD89C64209711220041C951 /* UIStackView+Extensions.swift in Sources */,
 				BD7222012094F4D500D28B9C /* NSLayoutConstraints+iOS.swift in Sources */,
 			);
@@ -779,6 +794,7 @@
 				BD7221F92094F41500D28B9C /* View+Extensions.swift in Sources */,
 				BD722205209636BB00D28B9C /* NSCollectionView+Extensions.swift in Sources */,
 				BD7221DA2094F2B100D28B9C /* UserInterfaceLabel.swift in Sources */,
+				BDF8BD05214D8F0D00D1C5E1 /* Shadow.swift in Sources */,
 				BD722209209637C300D28B9C /* NSStackView+Extensions.swift in Sources */,
 				BD7221FB2094F41D00D28B9C /* TypeAlias.swift in Sources */,
 			);


### PR DESCRIPTION
This PR adds a new `Shadow` struct to make it easier to set shadows to a view.
The motivation is to expose all properties that a layer uses for creating a shadow and to make it a more high-level function as you no longer have to interact with core graphics colors but instead us the top-level `UIColor` in the initialiser of the `Shadow` struct.